### PR TITLE
add user to group when register

### DIFF
--- a/backend/authentication/urls.py
+++ b/backend/authentication/urls.py
@@ -3,7 +3,7 @@ from . import views
 from rest_framework import routers
 
 router = routers.SimpleRouter()
-router.register(r'user', views.UserViewSet, basename="user")
+router.register(r'users', views.UsersViewSet, basename="users")
 router.register(r'scout-hierarchy', views.ScoutHierarchyViewSet)
 router.register(r'zip-code', views.ZipCodeViewSet)
 router.register(r'eat-habit-type', views.EatHabitTypeViewSet)

--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -25,7 +25,7 @@ keycloak_admin = KeycloakAdmin(server_url=env('BASE_URI'),
 
 
 # Create your views here.
-class UserViewSet(viewsets.ViewSet):
+class UsersViewSet(viewsets.ViewSet):
 
     def get(self, request, *args, **kwargs):
         user_id = request.GET['user_id']


### PR DESCRIPTION
To add a user to a group, the group-id is needed.
The group-id of the the corresponding group-name is looked up recursively and if the group can't be found, a 400-error is returned.